### PR TITLE
Mark myself as vacation or whatever

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -594,7 +594,7 @@ cc = ["@nnethercote"]
 [assign]
 warn_non_default_branch = true
 contributing_url = "https://rustc-dev-guide.rust-lang.org/getting-started.html"
-users_on_vacation = ["jyn514", "jackh726"]
+users_on_vacation = ["jyn514", "jackh726", "WaffleLapkin"]
 
 [assign.adhoc_groups]
 compiler-team = [


### PR DESCRIPTION
I think I have the capacity to review PRs currently assigned to me, before vacation, but I won't be able to take any more. So, until everything settles down, I don't want to be assigned to new PRs.