### PR TITLE
add doc alias `replace_first` for `str::replacen`

### DIFF
--- a/library/alloc/src/str.rs
+++ b/library/alloc/src/str.rs
@@ -320,6 +320,7 @@ impl str {
     /// ```
     #[cfg(not(no_global_oom_handling))]
     #[rustc_allow_incoherent_impl]
+    #[doc(alias = "replace_first")]
     #[must_use = "this returns the replaced string as a new allocation, \
                   without modifying the original"]
     #[stable(feature = "str_replacen", since = "1.16.0")]


### PR DESCRIPTION
<!-- homu-ignore:start -->
<!--
If this PR is related to an unstable feature or an otherwise tracked effort,
please link to the relevant tracking issue here. If you don't know of a related
tracking issue or there are none, feel free to ignore this.

This PR will get automatically assigned to a reviewer. In case you would like
a specific user to review your work, you can assign it to them by using

    r? <reviewer name>
-->
<!-- homu-ignore:end -->

`replace_first` is a sensible name for a function, analogous to actually existing `<[_]>::split_first`, for example. (I just saw someone try to search for it)

I think it's reasonable to add such an alias for `replacen` which replaces the first occurrence of passed a 1.